### PR TITLE
Change CommonJS export to ES Module in testRouter.js

### DIFF
--- a/Server/routes/testRouter.js
+++ b/Server/routes/testRouter.js
@@ -173,6 +173,7 @@ router.get("/suggest/:id", async (req, res) => {
   }
 });
 
-module.exports = router;
+// module.exports = router;
+//type is not common js 
 
 export default router;


### PR DESCRIPTION
Hi, I'm Aditya (GSSoC'25 Participant) 👋

While working with the project locally, I encountered an issue in the backend file routes/testRouter.js at line 176. The export syntax used was CommonJS (module.exports), but the project is defined as a module in package.json ("type": "module").
This caused the following error on my machine (screenshot attached):

SyntaxError: Cannot use 'module.exports' with ES modules

🔧 Fix
I updated the export to ES Module syntax:

`export default router;`


<img width="1681" height="441" alt="image" src="https://github.com/user-attachments/assets/7fa1bdd5-2ca5-42f7-bdda-251ecbede65d" />

