### PR TITLE
Fixes homepage main title, text and cursor responsiveness

### DIFF
--- a/Client/src/components/Custom/LandingPage.tsx
+++ b/Client/src/components/Custom/LandingPage.tsx
@@ -109,11 +109,11 @@ const TextGenerateEffect: React.FC<Props> = ({ words, className }) => {
   ></div>
 
   <div className="container mx-auto px-4 py-20 md:py-32 mt-15 ">
-    <div className="grid md:grid-cols-2 gap-12 items-center">
+    <div className="grid md:grid-cols-2 gap-14 items-center">
       {/* Left Content */}
       <div className="space-y-8">
         <TypewriterEffect
-          className="text-4xl md:text-5xl lg:text-6xl font-bold text-indigo-500 leading-tight"
+          className="text-3xl md:text-4xl lg:text-5xl font-bold text-indigo-500 leading-tight"
           words={[
             { text: "Ace" },
             { text: "Your" },
@@ -126,7 +126,7 @@ const TextGenerateEffect: React.FC<Props> = ({ words, className }) => {
           ]}
         />
         <TextGenerateEffect
-          className={`text-2xl font-thin transition-colors duration-500 ${
+          className={`text-lg sm:text-xl lg:text-2xl text-center font-thin transition-colors duration-500 ${
             darkMode ? "text-gray-100" : "text-gray-700"
           }`}
           words="Master technical and aptitude questions while practicing real-time interviews with our AI assistant."

--- a/Client/src/components/ui/typewriter-effect.tsx
+++ b/Client/src/components/ui/typewriter-effect.tsx
@@ -72,7 +72,7 @@ import { useEffect } from "react";
   return (
     <div
       className={cn(
-        "text-base sm:text-xl md:text-3xl lg:text-5xl font-bold text-center",
+        "text-inherit font-bold text-center",
         className
       )}
     >
@@ -90,7 +90,7 @@ import { useEffect } from "react";
           repeatType: "reverse",
         }}
         className={cn(
-          "inline-block rounded-sm w-[4px] h-4 md:h-6 lg:h-10 bg-blue-500",
+          "inline-block rounded-sm w-[4px] h-6 md:h-6 lg:h-10 bg-blue-500",
           cursorClassName
         )}
       ></motion.span>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #206 

## What changes are included in this PR?

Fixed responsiveness in the homepage hero section:
- Updated **main title**  for responsive sizing. (previously broken due to spans overriding parent font-size)
- Updated  TextGenerateEffect text for proper responsiveness.
- Fixed  TypewriterEffect cursor height  to match responsive text sizes.

## Are these changes tested?

✅  Tested visually across **mobile, tablet, and desktop breakpoints** to ensure text and cursor scale correctly.
✅  No automated tests were added since these are visual/UX fixes.

## Screenshots

<img width="1195" height="821" alt="main_title" src="https://github.com/user-attachments/assets/aabdf59b-7eba-4a5c-b44a-ea7ffdfb1b95" />



